### PR TITLE
Adding help tab to editor screen

### DIFF
--- a/includes/class-boldgrid-seo-helptab.php
+++ b/includes/class-boldgrid-seo-helptab.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * BoldGrid Source Code
+ *
+ * @package Boldgrid_Seo_Helptab
+ * @copyright BoldGrid.com
+ * @version $Id$
+ * @author BoldGrid.com <wpb@boldgrod.com>
+ */
+
+/**
+ * Boldgrid Seo Helptab Class
+ *
+ * Responsible for adding the helptab to the editor.
+ *
+ * @since 1.6.3
+ */
+class Boldgrid_Seo_Helptab {
+	/**
+	 * Add our help tab.
+	 *
+	 * @since 1.6.3
+	 */
+	public function add() {
+		$screen = get_current_screen();
+
+		$args = array(
+			'id'      => 'boldgrid_seo',
+			'title'   => 'BoldGrid Easy SEO',
+			'content' => '<p>' . wp_kses(
+				sprintf(
+					// translators: 1 opening anchor tag to the Getting Started Guides, 2 its closing anchor tag, 3 opening anchor tag to Facebook user group.
+					__( 'If you have any questions on getting started with BoldGrid Easy SEO, please visit our %1$sGetting Started Guide%2$s. We also suggest joining our %3$sTeam Orange User Group community%2$s for free support, tips and tricks.', 'boldgrid-backup' ),
+					'<a href="https://www.boldgrid.com/support/boldgrid-easy-seo/" target="_blank">',
+					'</a>',
+					'<a href="https://www.facebook.com/groups/BGTeamOrange" target="_blank">'
+				),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+				)
+			) . '</p>',
+		);
+
+		$screen->add_help_tab( $args );
+	}
+}

--- a/includes/class-boldgrid-seo.php
+++ b/includes/class-boldgrid-seo.php
@@ -146,7 +146,9 @@ class Boldgrid_Seo {
 	 * @access private
 	 */
 	private function boldgrid_seo_admin() {
-		$admin = new Boldgrid_Seo_Admin( $this->configs );
+		$admin   = new Boldgrid_Seo_Admin( $this->configs );
+		$helptab = new Boldgrid_Seo_Helptab();
+
 		$this->loader->add_action( 'wp_head', $admin, 'wp_head', 1 );
 		$this->loader->add_action( "{$this->prefix}/seo/description", $admin, 'meta_description' );
 		$this->loader->add_action( "{$this->prefix}/seo/robots", $admin, 'robots' );
@@ -157,6 +159,9 @@ class Boldgrid_Seo {
 		$this->loader->add_action( "{$this->prefix}/seo/og:type", $admin, 'meta_og_type' );
 		$this->loader->add_action( "{$this->prefix}/seo/og:url", $admin, 'meta_og_url' );
 		$this->loader->add_action( "{$this->prefix}/seo/og:description", $admin, 'meta_og_description' );
+
+		$this->loader->add_action( 'load-post.php', $helptab, 'add' );
+		$this->loader->add_action( 'load-post-new.php', $helptab, 'add' );
 
 		// Check version for updated filters
 		$wp_version = version_compare( get_bloginfo( 'version' ), '4.4', '>=' );


### PR DESCRIPTION
# Testing instructions
* [ ] While editing a page, click the help tab at the top right.
* [ ] There should be a BoldGrid Easy SEO tab, you should see a link to the Team Orange User Group. Ensure verbiage sounds good and link works as expected.