### PR TITLE
Remove Core rel_canonical action if specified by user.

### DIFF
--- a/includes/class-boldgrid-seo-admin.php
+++ b/includes/class-boldgrid-seo-admin.php
@@ -162,6 +162,9 @@ class Boldgrid_Seo_Admin {
 		if ( ! empty( $GLOBALS['post']->ID ) && $canonical = get_post_meta( $GLOBALS['post']->ID, 'bgseo_canonical', true ) ) {
 			// Look for a custom canonical url to override the default permalink.
 			$content = $canonical;
+			remove_action('wp_head', 'rel_canonical');
+		} else {
+			return;
 		}
 
 		if ( ! empty( $content ) ) : printf( $this->settings['meta_fields']['canonical'] . "\n", esc_url( $content ) ); endif;


### PR DESCRIPTION
Resolves #9 
If the user has specified a value for the canonical URL, remove the wp_head action [rel_canonical](https://developer.wordpress.org/reference/functions/rel_canonical/)
If the user has left the canonical URL blank, return from the function without printing a second canonical URL.