### PR TITLE
add woocommerce products to seo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Contributors:** boldgrid, timph, rramo012, imh_brad, joemoto, jamesros161
 **Tags:** seo, search engine optimization, content analysis, readability, boldgrid
 **Requires at least:** 4.4
-**Tested up to:** 5.6
+**Tested up to:** 6.2
 **Requires PHP:** 5.3
 **Stable tag:** 1.6.11
 **License:** GPLv2 or later

--- a/includes/configs/meta-box.config.php
+++ b/includes/configs/meta-box.config.php
@@ -2,7 +2,8 @@
 return array(
 	'post_types' => array(
 		'post',
-		'page'
+		'page',
+		'product',
 	),
 	'nonce'      => array(
 		'action'     => 'boldgrid-seo',
@@ -10,7 +11,7 @@ return array(
 	),
 	'manager' => array(
 			'label'     => __( 'Easy SEO', 'bgseo' ),
-			'post_type' => array( 'post', 'page' ),
+			'post_type' => array( 'post', 'page', 'product' ),
 			'context'   => 'normal',
 			'priority'  => 'high',
 	),


### PR DESCRIPTION
Fixes #54 

TEST FILE:
[boldgrid-easy-seo.zip](https://github.com/BoldGrid/boldgrid-seo/files/11254010/boldgrid-easy-seo.zip)

Testing Instructions:
1. Install BG Seo from the zip file provided.
2. Install WooCommerce
3. Edit or create a WooCommerce product.
4. Ensure the BG SEO tools show up.
