### PR TITLE
Php8.2 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ The BoldGrid Easy SEO plugin is open source software. Join in on our [GitHub rep
 
 ## Changelog ##
 
+### 1.6.13 ###
+
+Release date: May 23rd, 2023
+
+* Update: Fix PHP 8.2 Deprecation notices.
+
 ### 1.6.12 ###
 
 Release Date: April, 20, 2023

--- a/boldgrid-easy-seo.php
+++ b/boldgrid-easy-seo.php
@@ -14,7 +14,7 @@
  * Plugin Name: BoldGrid Easy SEO
  * Plugin URI: https://www.boldgrid.com/boldgrid-seo/
  * Description: Easily manage your website's search engine optimization with Easy SEO by BoldGrid!
- * Version: 1.6.12
+ * Version: 1.6.13
  * Author: BoldGrid <support@boldgrid.com>
  * Author URI: https://www.boldgrid.com/
  * License: GPL-2.0+

--- a/includes/class-boldgrid-seo-admin.php
+++ b/includes/class-boldgrid-seo-admin.php
@@ -45,6 +45,14 @@ class Boldgrid_Seo_Admin {
 	protected $configs;
 
 	/**
+	 * An instance of the Boldgrid_Seo_Util class
+	 *
+	 * @since 1.2.1
+	 * @var Boldgrid_Seo_Util
+	 */
+	public $util;
+
+	/**
 	 * Define the core functionality of the plugin.
 	 *
 	 * @since    1.0.0

--- a/includes/class-boldgrid-seo-butterbean.php
+++ b/includes/class-boldgrid-seo-butterbean.php
@@ -1,5 +1,23 @@
 <?php
 class Boldgrid_Seo_Butterbean {
+	/**
+	 * The unique identifier of this plugin.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array $configs Configs array.
+	 */
+	public $configs;
+
+	/**
+	 * An instance of the Boldgrid_Seo_Util class
+	 *
+	 * @since 1.2.1
+	 *
+	 * @var Boldgrid_Seo_Util
+	 */
+	public $util;
+
 	public function __construct( $configs ) {
 		$this->configs = $configs;
 		$this->util = new Boldgrid_Seo_Util();

--- a/includes/class-boldgrid-seo-config.php
+++ b/includes/class-boldgrid-seo-config.php
@@ -28,6 +28,14 @@ class Boldgrid_Seo_Config implements Boldgrid_Seo_Config_Interface {
 	protected $configs;
 
 	/**
+	 * An instance of the Boldgrid_Seo_Util class
+	 *
+	 * @since 1.2.1
+	 * @var Boldgrid_Seo_Util
+	 */
+	public $util;
+
+	/**
 	 * Get configs.
 	 */
 	public function get_configs() {

--- a/includes/class-boldgrid-seo-scripts.php
+++ b/includes/class-boldgrid-seo-scripts.php
@@ -15,6 +15,15 @@ class Boldgrid_Seo_Scripts {
 
 	protected $configs;
 
+	/**
+	 * An instance of the Boldgrid_Seo_Admin class
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Boldgrid_Seo_Admin
+	 */
+	public $admin;
+
 	public function __construct( $configs ) {
 		$this->configs = $configs;
 		$this->admin = new Boldgrid_Seo_Admin( $this->configs );

--- a/includes/class-boldgrid-seo.php
+++ b/includes/class-boldgrid-seo.php
@@ -39,6 +39,15 @@ class Boldgrid_Seo {
 	protected $plugin_name;
 
 	/**
+	 * Plugin Prefix
+	 *
+	 * @since 1.0.0
+	 * @access protected
+	 * @var string $prefix Plugin prefix string
+	 */
+	protected $prefix;
+
+	/**
 	 * The plugins configs.
 	 *
 	 * @since 1.0.0

--- a/includes/lib/butterbean/class-butterbean.php
+++ b/includes/lib/butterbean/class-butterbean.php
@@ -103,6 +103,15 @@ if ( ! class_exists( 'ButterBean' ) ) {
 		public $is_new_post = false;
 
 		/**
+		 * Post Id.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @var string $post_id Post Id.
+		 */
+		public $post_id;
+
+		/**
 		 * Returns the instance.
 		 *
 		 * @since  1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-seo",
-  "version": "1.6.12",
+  "version": "1.6.13",
   "description": "Easy SEO provides website search engine optimization.",
   "main": "gulpfile.js",
   "engines": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: seo, search engine optimization, content analysis, readability, boldgrid
 Requires at least: 4.4
 Tested up to: 6.2
 Requires PHP: 5.3
-Stable tag: 1.6.12
+Stable tag: 1.6.13
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -77,6 +77,12 @@ The BoldGrid Easy SEO plugin is open source software. Join in on our [GitHub rep
 3. Search Visibility.
 
 == Changelog ==
+
+= 1.6.13 =
+
+Release date: May 23rd, 2023
+
+* Update: Fix PHP 8.2 Deprecation notices.
 
 = 1.6.12 =
 


### PR DESCRIPTION
This resolves a handful of PHP8.2 Deprecated warnings. Mostly, it is resolving the following:
* Adding dynamic properties is deprecated
* strpos() argument 1 cannot be null